### PR TITLE
Update NuGet packages for improved functionality

### DIFF
--- a/src/ConsoleAOAI-04-VideoAnalyzer/ConsoleAOAI-04-VideoAnalyzer.csproj
+++ b/src/ConsoleAOAI-04-VideoAnalyzer/ConsoleAOAI-04-VideoAnalyzer.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
     <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
   </ItemGroup>
 

--- a/src/ConsoleApp1/ConsoleApp1.csproj
+++ b/src/ConsoleApp1/ConsoleApp1.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.3-preview.1.25230.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ConsoleMEAI-04-OpenAI/ConsoleMEAI-04-OpenAI.csproj
+++ b/src/ConsoleMEAI-04-OpenAI/ConsoleMEAI-04-OpenAI.csproj
@@ -17,9 +17,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
 		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.3-preview.1.25230.7" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 	</ItemGroup>
 
 </Project>

--- a/src/ConsoleMEAI-05-GitHubModels/ConsoleMEAI-05-GitHubModels.csproj
+++ b/src/ConsoleMEAI-05-GitHubModels/ConsoleMEAI-05-GitHubModels.csproj
@@ -17,9 +17,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
 		<PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 	</ItemGroup>
 
 </Project>

--- a/src/ConsoleMEAI-06-Ollama/ConsoleMEAI-06-Ollama.csproj
+++ b/src/ConsoleMEAI-06-Ollama/ConsoleMEAI-06-Ollama.csproj
@@ -16,9 +16,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
 		<PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.4.3-preview.1.25230.7" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 	</ItemGroup>
 
 </Project>

--- a/src/ConsoleMEAI-07-AOAI/ConsoleMEAI-07-AOAI.csproj
+++ b/src/ConsoleMEAI-07-AOAI/ConsoleMEAI-07-AOAI.csproj
@@ -15,12 +15,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
+	  <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
 	  <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
 	  <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.3-preview.1.25230.7" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-	  <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-	  <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+	  <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+	  <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 	  <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
 	</ItemGroup>
 

--- a/src/ConsoleOpenAI-01-ChatComplete/ConsoleOpenAI-01-ChatComplete.csproj
+++ b/src/ConsoleOpenAI-01-ChatComplete/ConsoleOpenAI-01-ChatComplete.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="OpenAI" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+    <PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
   </ItemGroup>
 
 </Project>

--- a/src/ConsoleOpenAI-02-AnalyseImage/ConsoleOpenAI-03-AnalyseImage.csproj
+++ b/src/ConsoleOpenAI-02-AnalyseImage/ConsoleOpenAI-03-AnalyseImage.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="OpenAI" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+    <PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
   </ItemGroup>
 
 </Project>

--- a/src/ConsoleOpenAI-02-ChatStreaming/ConsoleOpenAI-02-ChatStreaming.csproj
+++ b/src/ConsoleOpenAI-02-ChatStreaming/ConsoleOpenAI-02-ChatStreaming.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="OpenAI" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+    <PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
   </ItemGroup>
 
 </Project>

--- a/src/ConsoleOpenAI-04-VideoAnalyzer/ConsoleOpenAI-04-VideoAnalyzer.csproj
+++ b/src/ConsoleOpenAI-04-VideoAnalyzer/ConsoleOpenAI-04-VideoAnalyzer.csproj
@@ -10,10 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-		<PackageReference Include="OpenAI" Version="2.1.0-beta.1" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenAI" Version="2.2.0-beta.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ConsoleSK-01-AOAI/ConsoleSK-01-AOAI.csproj
+++ b/src/ConsoleSK-01-AOAI/ConsoleSK-01-AOAI.csproj
@@ -14,10 +14,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.25.0" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.48.0" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 		<PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
 	</ItemGroup>
 </Project>

--- a/src/OpenCV-Camera-01/OpenCV-Camera-01.csproj
+++ b/src/OpenCV-Camera-01/OpenCV-Camera-01.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenCV-Camera-02-FPS/OpenCV-Camera-02-FPS.csproj
+++ b/src/OpenCV-Camera-02-FPS/OpenCV-Camera-02-FPS.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenCV-Camera-04-BlurFaces/OpenCV-Camera-04-BlurFaces.csproj
+++ b/src/OpenCV-Camera-04-BlurFaces/OpenCV-Camera-04-BlurFaces.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenCV-Camera-05-PlayVideo/OpenCV-Camera-05-PlayVideo.csproj
+++ b/src/OpenCV-Camera-05-PlayVideo/OpenCV-Camera-05-PlayVideo.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
     <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
   </ItemGroup>
 

--- a/src/OpenCV-Camera-06-VideoSaveFrames/OpenCV-Camera-06-VideoSaveFrames.csproj
+++ b/src/OpenCV-Camera-06-VideoSaveFrames/OpenCV-Camera-06-VideoSaveFrames.csproj
@@ -10,8 +10,8 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 		<PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/SpectreConsole-MEAI-01-Ollama/SpectreConsole-MEAI-01-Ollama.csproj
+++ b/src/SpectreConsole-MEAI-01-Ollama/SpectreConsole-MEAI-01-Ollama.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.4.3-preview.1.25230.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
+    <PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.5" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.50.1-preview.0.5" />
   </ItemGroup>
 </Project>

--- a/src/SpectreConsole-MEAI-02-GHModels/SpectreConsole-MEAI-02-GHModels.csproj
+++ b/src/SpectreConsole-MEAI-02-GHModels/SpectreConsole-MEAI-02-GHModels.csproj
@@ -18,10 +18,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
 		<PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
-		<PackageReference Include="Spectre.Console" Version="0.49.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
+		<PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/SpectreConsole-MEAI-03-AOAI/SpectreConsole-MEAI-03-AOAI.csproj
+++ b/src/SpectreConsole-MEAI-03-AOAI/SpectreConsole-MEAI-03-AOAI.csproj
@@ -13,15 +13,15 @@
     <Compile Include="..\VideosHelper.cs" Link="VideosHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
     <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.3-preview.1.25230.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
     <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.5" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.50.1-preview.0.5" />
   </ItemGroup>
 </Project>

--- a/src/SpectreConsole-MEAI-04-Phi35OnAzure/SpectreConsole-MEAI-04-Phi35OnAzure.csproj
+++ b/src/SpectreConsole-MEAI-04-Phi35OnAzure/SpectreConsole-MEAI-04-Phi35OnAzure.csproj
@@ -18,10 +18,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
 		<PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0-rc.2.24473.5" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.45" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
+		<PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/SpectreConsole-SK-01-AOAI/SpectreConsole-SK-01-AOAI.csproj
+++ b/src/SpectreConsole-SK-01-AOAI/SpectreConsole-SK-01-AOAI.csproj
@@ -16,14 +16,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+		<PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.4" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
 		<PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" />
-		<PackageReference Include="Spectre.Console" Version="0.49.1" />
-		<PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
+		<PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.5" />
+		<PackageReference Include="Spectre.Console.Json" Version="0.50.1-preview.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/openCV-Camera-03-IPCam/openCV-Camera-03-IPCam.csproj
+++ b/src/openCV-Camera-03-IPCam/openCV-Camera-03-IPCam.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Purpose

Upgraded several NuGet packages across multiple projects:
- `Microsoft.Extensions.Configuration.UserSecrets` to 9.0.4
- `OpenCvSharp4` and `OpenCvSharp4.runtime.win` to 4.11.0.20250507
- `Azure.AI.OpenAI` to 2.2.0-beta.4
- `Spectre.Console` and `Spectre.Console.Json` to 0.50.1-preview.0.5

These updates enhance functionality, security, and compatibility with newer features.

This pull request updates package dependencies across multiple project files to ensure compatibility with newer versions and improve functionality. The updates primarily affect the `Azure.AI.OpenAI`, `OpenCvSharp4`, `Microsoft.Extensions.Configuration.UserSecrets`, and `Spectre.Console` packages.

### Dependency Updates:

#### Azure.AI.OpenAI:
* Updated to version `2.2.0-beta.4` in several projects, replacing older versions like `2.0.0` and `2.1.0-beta.1`. (`[[1]](diffhunk://#diff-d61c4cf729b107c1083ae5a15fe1fb9a4b2faa86743c4807ecfc292512044eecL18-R21)`, `[[2]](diffhunk://#diff-cdb0f3617791565a969efd9a40015990de46398d84fbfb0b3c3363ee43e658d3L18-R23)`, `[[3]](diffhunk://#diff-f0582814e65516c2e14310e11a6b27c9d5ec2c43e4a4c6e1d1666cfc4147f09aL16-R25)`)

#### OpenCvSharp4:
* Updated `OpenCvSharp4` and `OpenCvSharp4.runtime.win` to version `4.11.0.20250507` across all affected projects, replacing version `4.10.0.20240616`. (`[[1]](diffhunk://#diff-d61c4cf729b107c1083ae5a15fe1fb9a4b2faa86743c4807ecfc292512044eecL18-R21)`, `[[2]](diffhunk://#diff-a424cf69d502faf5754191b10199a98d762cf178c411cb132ec8e85fe5e05782L12-R13)`, `[[3]](diffhunk://#diff-10ff7c0dde2a46184715507792c60d13d1308f6e1043a3338c6efcda441287ebL21-R24)`, `[[4]](diffhunk://#diff-61cbdd32509f9ffca3dd28b98e7883a966c6e1ef5727d7220166a0fd0bc67651L21-R24)`)

#### Microsoft.Extensions.Configuration.UserSecrets:
* Updated to version `9.0.4` across all projects, replacing older versions like `8.0.0`, `8.0.1`, and `9.0.1`. (`[[1]](diffhunk://#diff-e398abb4d44e9b247c8be79c21c74df05b05994fa8136be25698f644d7faa48bL26-R26)`, `[[2]](diffhunk://#diff-0e4133bd1cf105142d1ac474ff9b605b936699fed5b172036dd93091f8f5a7c7L20-R22)`, `[[3]](diffhunk://#diff-5d8fd8c8327cabbcf751580ae0efc2ea4745be04749b715f44579d71b88105aaL17-R21)`, `[[4]](diffhunk://#diff-6aec84c300d078d327165595608c1003d37a095f2982d11c390c169e9848a0ddL17-R20)`)

#### Spectre.Console:
* Updated `Spectre.Console` and `Spectre.Console.Json` to version `0.50.1-preview.0.5` in relevant projects, replacing older versions like `0.49.1` and `0.49.2-preview.0.45`. (`[[1]](diffhunk://#diff-5d8fd8c8327cabbcf751580ae0efc2ea4745be04749b715f44579d71b88105aaL17-R21)`, `[[2]](diffhunk://#diff-f0582814e65516c2e14310e11a6b27c9d5ec2c43e4a4c6e1d1666cfc4147f09aL16-R25)`, `[[3]](diffhunk://#diff-61cbdd32509f9ffca3dd28b98e7883a966c6e1ef5727d7220166a0fd0bc67651L21-R24)`)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```